### PR TITLE
Toggle the window's theme in the example

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -292,6 +292,24 @@ impl Window {
     pub fn set_physical_cursor_position(&mut self, position: Option<DVec2>) {
         self.internal.physical_cursor_position = position;
     }
+
+    /// The window's current theme
+    ///
+    /// ## Platform-specific
+    ///
+    /// - iOS / Android / Web / x11: Unsupported.
+    pub fn window_theme(&self) -> Option<WindowTheme> {
+        self.internal.window_theme
+    }
+
+    /// Set the window's theme
+    ///
+    /// ## Platform-specific
+    ///
+    /// - iOS / Android / Web / x11: Unsupported.
+    pub fn set_window_theme(&mut self, theme: Option<WindowTheme>) {
+        self.internal.window_theme = theme;
+    }
 }
 
 /// The size limits on a window.
@@ -667,6 +685,12 @@ pub struct InternalWindowState {
     maximize_request: Option<bool>,
     /// Unscaled cursor position.
     physical_cursor_position: Option<DVec2>,
+    /// The window's current theme
+    ///
+    /// ## Platform-specific
+    ///
+    /// - iOS / Android / Web / x11: Unsupported.
+    window_theme: Option<WindowTheme>,
 }
 
 impl InternalWindowState {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -23,7 +23,7 @@ use winit::{
 use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandlers},
-    converters::{self, convert_window_level},
+    converters::{self, convert_window_level, convert_winit_theme},
     get_best_videomode, get_fitting_videomode, WinitWindows,
 };
 
@@ -62,6 +62,11 @@ pub(crate) fn create_window<'a>(
             &mut handlers,
             &mut accessibility_requested,
         );
+
+        if let Some(theme) = winit_window.theme() {
+            window.set_window_theme(Some(convert_winit_theme(theme)));
+        }
+
         window
             .resolution
             .set_scale_factor(winit_window.scale_factor());
@@ -294,6 +299,12 @@ pub(crate) fn changed_window(
                     window.ime_position.x,
                     window.ime_position.y,
                 ));
+            }
+
+            if window.window_theme() != cache.window.window_theme() {
+                if let Some(theme) = window.window_theme() {
+                    winit_window.set_theme(Some(converters::convert_window_theme(theme)));
+                }
             }
 
             cache.window = window.clone();

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -23,7 +23,7 @@ use winit::{
 use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandlers},
-    converters::{self, convert_window_level, convert_winit_theme},
+    converters::{self, convert_window_level, convert_winit_theme, convert_window_theme},
     get_best_videomode, get_fitting_videomode, WinitWindows,
 };
 
@@ -303,7 +303,7 @@ pub(crate) fn changed_window(
 
             if window.window_theme() != cache.window.window_theme() {
                 if let Some(theme) = window.window_theme() {
-                    winit_window.set_theme(Some(converters::convert_window_theme(theme)));
+                    winit_window.set_theme(Some(convert_window_theme(theme)));
                 }
             }
 

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -4,7 +4,7 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{CursorGrabMode, PresentMode, WindowLevel},
+    window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
 };
 
 fn main() {
@@ -28,6 +28,7 @@ fn main() {
             Update,
             (
                 change_title,
+                toggle_theme,
                 toggle_cursor,
                 toggle_vsync,
                 cycle_cursor_icon,
@@ -90,6 +91,20 @@ fn toggle_cursor(mut windows: Query<&mut Window>, input: Res<Input<KeyCode>>) {
             CursorGrabMode::None => CursorGrabMode::Locked,
             CursorGrabMode::Locked | CursorGrabMode::Confined => CursorGrabMode::None,
         };
+    }
+}
+
+// This system will toggle the color theme used by the window
+fn toggle_theme(mut windows: Query<&mut Window>, input: Res<Input<KeyCode>>) {
+    if input.just_pressed(KeyCode::F) {
+        let mut window = windows.single_mut();
+
+        if let Some(current_theme) = window.window_theme() {
+            window.set_window_theme(match current_theme {
+                WindowTheme::Light => Some(WindowTheme::Dark),
+                WindowTheme::Dark => Some(WindowTheme::Light),
+            });
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Add the ability to toggle the window's theme in the window_settings.rs example

## Solution

- Added window_theme: Option<WindowTheme> to the window's WindowInternalState
- Added window_theme(&self) and set_window_theme(&mut self, theme: Option<WindowTheme>)