### PR TITLE
Be clear as to when the event is sent.

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -295,7 +295,8 @@ pub struct WindowMoved {
 
 /// An event that is sent when system changed window theme.
 ///
-/// It is only sent when [`Window::preferred_theme`](crate::window::Window::preferred_theme) is `None`.
+/// This event is only sent when the window is relying on the system theme to control its appearance.
+/// i.e. It is only sent when [`Window::preferred_theme`](crate::window::Window::preferred_theme) is `None` and the system theme changes.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(


### PR DESCRIPTION
# Objective

Explain when the `WindowThemeEvent` event is fired.

## Solution

- Add more explicit comment stating when the `WindowThemeEvent` event is sent.