### PR TITLE
Refactor code around window themeing

### DIFF
--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -27,3 +27,9 @@ raw-window-handle = "0.5"
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
+winit = { version = "0.28", default-features = false }
+
+[target.'cfg(target_os = "android")'.dependencies]
+winit = { version = "0.28", default-features = false, features = [
+    "android-native-activity",
+] }

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -296,7 +296,7 @@ pub struct WindowMoved {
 /// An event sent when system changed window theme.
 ///
 /// This event is only sent when the window is relying on the system theme to control its appearance.
-/// i.e. It is only sent when [`Window::preferred_theme`](crate::window::Window::preferred_theme) is `None` and the system theme changes.
+/// i.e. It is only sent when [`Window::window_theme`](crate::window::Window::window_theme) is `None` and the system theme changes.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -191,7 +191,7 @@ pub struct Window {
     /// ## Platform-specific
     ///
     /// Ignored on iOS, Android, and Web.
-    pub preferred_theme: Option<WindowTheme>,
+    pub window_theme: Option<WindowTheme>,
 }
 
 impl Default for Window {
@@ -216,7 +216,7 @@ impl Default for Window {
             fit_canvas_to_parent: false,
             prevent_default_event_handling: true,
             canvas: None,
-            preferred_theme: None,
+            window_theme: None,
         }
     }
 }
@@ -291,24 +291,6 @@ impl Window {
     /// Set the physical cursor position in this window
     pub fn set_physical_cursor_position(&mut self, position: Option<DVec2>) {
         self.internal.physical_cursor_position = position;
-    }
-
-    /// The window's current theme
-    ///
-    /// ## Platform-specific
-    ///
-    /// Ignored on iOS, Android, and Web.
-    pub fn window_theme(&self) -> Option<WindowTheme> {
-        self.internal.window_theme
-    }
-
-    /// Set the window's theme
-    ///
-    /// ## Platform-specific
-    ///
-    /// Ignored on iOS, Android, and Web.
-    pub fn set_window_theme(&mut self, theme: Option<WindowTheme>) {
-        self.internal.window_theme = theme;
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -881,3 +881,21 @@ pub enum WindowTheme {
     /// Use the dark variant.
     Dark,
 }
+
+impl From<winit::window::Theme> for WindowTheme {
+    fn from(theme: winit::window::Theme) -> Self {
+        match theme {
+            winit::window::Theme::Light => WindowTheme::Light,
+            winit::window::Theme::Dark => WindowTheme::Dark,
+        }
+    }
+}
+
+impl From<WindowTheme> for winit::window::Theme {
+    fn from(theme: WindowTheme) -> Self {
+        match theme {
+            WindowTheme::Light => winit::window::Theme::Light,
+            WindowTheme::Dark => winit::window::Theme::Dark,
+        }
+    }
+}

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -190,7 +190,7 @@ pub struct Window {
     ///
     /// ## Platform-specific
     ///
-    /// Does nothing on iOS, Android, Web and x11.
+    /// Ignored on iOS, Android, and Web.
     pub preferred_theme: Option<WindowTheme>,
 }
 
@@ -297,7 +297,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - iOS / Android / Web / x11: Unsupported.
+    /// Ignored on iOS, Android, and Web.
     pub fn window_theme(&self) -> Option<WindowTheme> {
         self.internal.window_theme
     }
@@ -306,7 +306,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - iOS / Android / Web / x11: Unsupported.
+    /// Ignored on iOS, Android, and Web.
     pub fn set_window_theme(&mut self, theme: Option<WindowTheme>) {
         self.internal.window_theme = theme;
     }
@@ -689,7 +689,7 @@ pub struct InternalWindowState {
     ///
     /// ## Platform-specific
     ///
-    /// - iOS / Android / Web / x11: Unsupported.
+    /// Ignored on iOS, Android, and Web.
     window_theme: Option<WindowTheme>,
 }
 

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -5,7 +5,7 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::Vec2;
-use bevy_window::{CursorIcon, WindowLevel, WindowTheme};
+use bevy_window::{CursorIcon, WindowLevel};
 
 pub fn convert_keyboard_input(keyboard_input: &winit::event::KeyboardInput) -> KeyboardInput {
     KeyboardInput {
@@ -272,19 +272,5 @@ pub fn convert_window_level(window_level: WindowLevel) -> winit::window::WindowL
         WindowLevel::AlwaysOnBottom => winit::window::WindowLevel::AlwaysOnBottom,
         WindowLevel::Normal => winit::window::WindowLevel::Normal,
         WindowLevel::AlwaysOnTop => winit::window::WindowLevel::AlwaysOnTop,
-    }
-}
-
-pub fn convert_winit_theme(theme: winit::window::Theme) -> WindowTheme {
-    match theme {
-        winit::window::Theme::Light => WindowTheme::Light,
-        winit::window::Theme::Dark => WindowTheme::Dark,
-    }
-}
-
-pub fn convert_window_theme(theme: WindowTheme) -> winit::window::Theme {
-    match theme {
-        WindowTheme::Light => winit::window::Theme::Light,
-        WindowTheme::Dark => winit::window::Theme::Dark,
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -54,7 +54,6 @@ use winit::{
 
 use crate::accessibility::{AccessKitAdapters, AccessibilityPlugin, WinitActionHandlers};
 
-use crate::converters::convert_winit_theme;
 #[cfg(target_arch = "wasm32")]
 use crate::web_resize::{CanvasParentResizeEventChannel, CanvasParentResizePlugin};
 
@@ -618,7 +617,7 @@ pub fn winit_runner(mut app: App) {
                     WindowEvent::ThemeChanged(theme) => {
                         window_events.window_theme_changed.send(WindowThemeChanged {
                             window: window_entity,
-                            theme: convert_winit_theme(theme),
+                            theme: theme.into(),
                         });
                     }
                     _ => {}

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -23,7 +23,7 @@ use winit::{
 use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandlers},
-    converters::{self, convert_window_level, convert_window_theme, convert_winit_theme},
+    converters::{self, convert_window_level},
     get_best_videomode, get_fitting_videomode, WinitWindows,
 };
 
@@ -64,7 +64,7 @@ pub(crate) fn create_window<'a>(
         );
 
         if let Some(theme) = winit_window.theme() {
-            window.set_window_theme(Some(convert_winit_theme(theme)));
+            window.set_window_theme(Some(theme.into()));
         }
 
         window
@@ -302,9 +302,8 @@ pub(crate) fn changed_window(
             }
 
             if window.window_theme() != cache.window.window_theme() {
-                if let Some(theme) = window.window_theme() {
-                    winit_window.set_theme(Some(convert_window_theme(theme)));
-                }
+                let theme = window.window_theme();
+                winit_window.set_theme(theme.map(Into::into));
             }
 
             cache.window = window.clone();

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -64,7 +64,7 @@ pub(crate) fn create_window<'a>(
         );
 
         if let Some(theme) = winit_window.theme() {
-            window.set_window_theme(Some(theme.into()));
+            window.window_theme = Some(theme.into());
         }
 
         window
@@ -301,9 +301,8 @@ pub(crate) fn changed_window(
                 ));
             }
 
-            if window.window_theme() != cache.window.window_theme() {
-                let theme = window.window_theme();
-                winit_window.set_theme(theme.map(Into::into));
+            if window.window_theme != cache.window.window_theme {
+                winit_window.set_theme(window.window_theme.map(Into::into));
             }
 
             cache.window = window.clone();

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -18,7 +18,7 @@ use winit::{
 
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandler, WinitActionHandlers},
-    converters::{convert_window_level, convert_window_theme},
+    converters::convert_window_level,
 };
 
 /// A resource which maps window entities to [`winit`] library windows.
@@ -92,7 +92,7 @@ impl WinitWindows {
 
         winit_window_builder = winit_window_builder
             .with_window_level(convert_window_level(window.window_level))
-            .with_theme(window.preferred_theme.map(convert_window_theme))
+            .with_theme(window.preferred_theme.map(Into::into))
             .with_resizable(window.resizable)
             .with_decorations(window.decorations)
             .with_transparent(window.transparent);

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -92,7 +92,7 @@ impl WinitWindows {
 
         winit_window_builder = winit_window_builder
             .with_window_level(convert_window_level(window.window_level))
-            .with_theme(window.preferred_theme.map(Into::into))
+            .with_theme(window.window_theme.map(Into::into))
             .with_resizable(window.resizable)
             .with_decorations(window.decorations)
             .with_transparent(window.transparent);

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -18,7 +18,7 @@ fn main() {
                 fit_canvas_to_parent: true,
                 // Tells wasm not to override default event handling, like F5, Ctrl+R etc.
                 prevent_default_event_handling: false,
-                preferred_theme: Some(WindowTheme::Dark),
+                window_theme: Some(WindowTheme::Dark),
                 ..default()
             }),
             ..default()
@@ -100,11 +100,11 @@ fn toggle_theme(mut windows: Query<&mut Window>, input: Res<Input<KeyCode>>) {
     if input.just_pressed(KeyCode::F) {
         let mut window = windows.single_mut();
 
-        if let Some(current_theme) = window.window_theme() {
-            window.set_window_theme(match current_theme {
+        if let Some(current_theme) = window.window_theme {
+            window.window_theme = match current_theme {
                 WindowTheme::Light => Some(WindowTheme::Dark),
                 WindowTheme::Dark => Some(WindowTheme::Light),
-            });
+            };
         }
     }
 }


### PR DESCRIPTION
# Objective

- Address bugs and documentation errors

## Solution

- Implement the `From` trait for converting between `bevy_window::window::WindowTheme` and `winit::window::Theme` (Add `winit` dependency to `bevy_window` Cargo.toml )
- Remove mentions of `x11` from unsupported platforms
- Rename `preferred_theme` to `window_theme`
- Remove `window_theme` and `set_window_theme` methods from `bevy_window::window::Window`
- React to and modify the `window_theme` field directly instead of using the aforementioned methods
