### PR TITLE
Revert From trait implementation

### DIFF
--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -27,9 +27,3 @@ raw-window-handle = "0.5"
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }
-winit = { version = "0.28", default-features = false }
-
-[target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.28", default-features = false, features = [
-    "android-native-activity",
-] }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -667,12 +667,6 @@ pub struct InternalWindowState {
     maximize_request: Option<bool>,
     /// Unscaled cursor position.
     physical_cursor_position: Option<DVec2>,
-    /// The window's current theme
-    ///
-    /// ## Platform-specific
-    ///
-    /// Ignored on iOS, Android, and Web.
-    window_theme: Option<WindowTheme>,
 }
 
 impl InternalWindowState {
@@ -862,22 +856,4 @@ pub enum WindowTheme {
 
     /// Use the dark variant.
     Dark,
-}
-
-impl From<winit::window::Theme> for WindowTheme {
-    fn from(theme: winit::window::Theme) -> Self {
-        match theme {
-            winit::window::Theme::Light => WindowTheme::Light,
-            winit::window::Theme::Dark => WindowTheme::Dark,
-        }
-    }
-}
-
-impl From<WindowTheme> for winit::window::Theme {
-    fn from(theme: WindowTheme) -> Self {
-        match theme {
-            WindowTheme::Light => winit::window::Theme::Light,
-            WindowTheme::Dark => winit::window::Theme::Dark,
-        }
-    }
 }

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -5,7 +5,7 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::Vec2;
-use bevy_window::{CursorIcon, WindowLevel};
+use bevy_window::{CursorIcon, WindowLevel, WindowTheme};
 
 pub fn convert_keyboard_input(keyboard_input: &winit::event::KeyboardInput) -> KeyboardInput {
     KeyboardInput {
@@ -272,5 +272,19 @@ pub fn convert_window_level(window_level: WindowLevel) -> winit::window::WindowL
         WindowLevel::AlwaysOnBottom => winit::window::WindowLevel::AlwaysOnBottom,
         WindowLevel::Normal => winit::window::WindowLevel::Normal,
         WindowLevel::AlwaysOnTop => winit::window::WindowLevel::AlwaysOnTop,
+    }
+}
+
+pub fn convert_winit_theme(theme: winit::window::Theme) -> WindowTheme {
+    match theme {
+        winit::window::Theme::Light => WindowTheme::Light,
+        winit::window::Theme::Dark => WindowTheme::Dark,
+    }
+}
+
+pub fn convert_window_theme(theme: WindowTheme) -> winit::window::Theme {
+    match theme {
+        WindowTheme::Light => winit::window::Theme::Light,
+        WindowTheme::Dark => winit::window::Theme::Dark,
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -54,6 +54,7 @@ use winit::{
 
 use crate::accessibility::{AccessKitAdapters, AccessibilityPlugin, WinitActionHandlers};
 
+use crate::converters::convert_winit_theme;
 #[cfg(target_arch = "wasm32")]
 use crate::web_resize::{CanvasParentResizeEventChannel, CanvasParentResizePlugin};
 
@@ -617,7 +618,7 @@ pub fn winit_runner(mut app: App) {
                     WindowEvent::ThemeChanged(theme) => {
                         window_events.window_theme_changed.send(WindowThemeChanged {
                             window: window_entity,
-                            theme: theme.into(),
+                            theme: convert_winit_theme(theme),
                         });
                     }
                     _ => {}

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -23,7 +23,7 @@ use winit::{
 use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandlers},
-    converters::{self, convert_window_level},
+    converters::{self, convert_window_level, convert_window_theme, convert_winit_theme},
     get_best_videomode, get_fitting_videomode, WinitWindows,
 };
 
@@ -64,7 +64,7 @@ pub(crate) fn create_window<'a>(
         );
 
         if let Some(theme) = winit_window.theme() {
-            window.window_theme = Some(theme.into());
+            window.window_theme = Some(convert_winit_theme(theme));
         }
 
         window
@@ -302,7 +302,7 @@ pub(crate) fn changed_window(
             }
 
             if window.window_theme != cache.window.window_theme {
-                winit_window.set_theme(window.window_theme.map(Into::into));
+                winit_window.set_theme(window.window_theme.map(convert_window_theme));
             }
 
             cache.window = window.clone();

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -18,7 +18,7 @@ use winit::{
 
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandler, WinitActionHandlers},
-    converters::convert_window_level,
+    converters::{convert_window_level, convert_window_theme},
 };
 
 /// A resource which maps window entities to [`winit`] library windows.
@@ -92,7 +92,7 @@ impl WinitWindows {
 
         winit_window_builder = winit_window_builder
             .with_window_level(convert_window_level(window.window_level))
-            .with_theme(window.window_theme.map(Into::into))
+            .with_theme(window.window_theme.map(convert_window_theme))
             .with_resizable(window.resizable)
             .with_decorations(window.decorations)
             .with_transparent(window.transparent);


### PR DESCRIPTION
# Objective

- The added `winit` dependency to `bevy_window` is not desireable
- Remove unused field member in `InternalWindowState`

## Solution

- Revert to using converter functions rather than implementing the `From` trait for `winit::window::Theme` and `WindowTheme`
- Remove `window_theme` in `InternalWindowState`